### PR TITLE
Add getTrainName and getStopName methods to Train Network Observer

### DIFF
--- a/src/main/java/de/saschat/createcomputing/peripherals/TrainNetworkObserverPeripheral.java
+++ b/src/main/java/de/saschat/createcomputing/peripherals/TrainNetworkObserverPeripheral.java
@@ -70,6 +70,14 @@ public class TrainNetworkObserverPeripheral extends SmartPeripheral {
             List<Train> trainList = getTrains();
             return MethodResult.of(trainList.stream().map(a -> a.id.toString()).collect(Collectors.toList()));
         });
+        addMethod("getTrainName", (iComputerAccess, iLuaContext, iArguments) -> {
+            String b = iArguments.getString(0);
+            Optional<Train> first = getTrains().stream().filter(a -> a.id.toString().equals(b)).findFirst();
+            if (first.isEmpty())
+                return MethodResult.of(null);
+            Train train = first.get();
+            return MethodResult.of(new Gson().fromJson(Component.Serializer.toJson(train.name), Map.class));
+        });
         addMethod("getTrainSchedule", (iComputerAccess, iLuaContext, iArguments) -> {
             String b = iArguments.getString(0);
             Optional<Train> first = getTrains().stream().filter(a -> a.id.toString().equals(b)).findFirst();
@@ -150,6 +158,14 @@ public class TrainNetworkObserverPeripheral extends SmartPeripheral {
             Collection<GlobalStation> stations = getStations();
             return MethodResult.of(stations.stream().map(a -> a.id.toString()).collect(Collectors.toList()));
         }));
+        addMethod("getStopName", (iComputerAccess, iLuaContext, iArguments) -> {
+            String b = iArguments.getString(0);
+            Optional<GlobalStation> first = getStations().stream().filter(a -> a.id.toString().equals(b)).findFirst();
+            if (first.isEmpty())
+                return MethodResult.of(null);
+            GlobalStation station = first.get();
+            return MethodResult.of(station.name);
+        });
         addMethod("getStopWorldPosition", (iComputerAccess, iLuaContext, iArguments) -> {
             String b = iArguments.getString(0);
             Optional<GlobalStation> first = getStations().stream().filter(a -> a.id.toString().equals(b)).findFirst();


### PR DESCRIPTION
Train names are saved as formatted strings (although I'm not 100% sure if it's possible to format them without commands) so I've used the same JSON conversion as used for schedule names.

Stop names are strings, simple.