### PR TITLE
Update to 1.19.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ minecraft {
     //
     // Use non-default mappings at your own risk. They may not always work.
     // Simply re-run your setup task after changing the mappings to update your workspace.
-    mappings channel: 'official', version: '1.18.2'
+    mappings channel: 'official', version: '1.19.2'
 
     // accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
 
@@ -149,18 +149,27 @@ repositories {
             includeGroup "curse.maven"
         }
     }
+    maven {
+        name = 'tterrag maven'
+        url = 'https://maven.tterrag.com/'
+    }
 }
 
 dependencies {
     // Specify the version of Minecraft to use. If this is any group other than 'net.minecraft' it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency, and its patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.18.2-40.1.10'
+    minecraft 'net.minecraftforge:forge:1.19.2-43.1.1'
 
-    implementation fg.deobf("curse.maven:create-328085:3872145")
-    implementation fg.deobf("curse.maven:flywheel-486392:3871082")
+    jarJar(group: 'com.tterrag.registrate', name: 'Registrate', version: '[MC1.19-1.1.5,)') {
+        jarJar.pin(it, project.registrate_version)
+    }
+
+    implementation fg.deobf("com.simibubi.create:create-${create_minecraft_version}:${create_version}:all") { transitive = false }
+    implementation fg.deobf("com.jozufozu.flywheel:flywheel-forge-${flywheel_minecraft_version}:${flywheel_version}")
     implementation fg.deobf("curse.maven:cc-tweaked-282001:3709268")
     implementation fg.deobf("curse.maven:jade-324717:3865918")
+    implementation fg.deobf("com.tterrag.registrate:Registrate:${registrate_version}")
     // Real mod deobf dependency examples - these get remapped to your current mappings
     // compileOnly fg.deobf("mezz.jei:jei-${mc_version}:${jei_version}:api") // Adds JEI API as a compile dependency
     // runtimeOnly fg.deobf("mezz.jei:jei-${mc_version}:${jei_version}") // Adds the full JEI mod as a runtime dependency

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,7 @@
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
+create_minecraft_version = 1.19.2
+flywheel_minecraft_version = 1.19.2
+create_version = 0.5.0.d-7
+flywheel_version = 0.6.5-4
+registrate_version = MC1.19-1.1.5

--- a/src/main/java/de/saschat/createcomputing/Behaviours.java
+++ b/src/main/java/de/saschat/createcomputing/Behaviours.java
@@ -13,7 +13,7 @@ public class Behaviours {
                     "computerized_display_source"),
                 new TextDisplayBehaviour()
             ),
-            Registries.COMPUTERIZED_DISPLAY_SOURCE_TILE.get().delegate
+            Registries.COMPUTERIZED_DISPLAY_SOURCE_TILE.get()
         );
         AllDisplayBehaviours.assignTile(
             AllDisplayBehaviours.register(
@@ -21,7 +21,7 @@ public class Behaviours {
                     "computerized_display_target"),
                 new TextPassBehaviour()
             ),
-            Registries.COMPUTERIZED_DISPLAY_TARGET_TILE.get().delegate
+            Registries.COMPUTERIZED_DISPLAY_TARGET_TILE.get()
         );
     }
 }

--- a/src/main/java/de/saschat/createcomputing/Registries.java
+++ b/src/main/java/de/saschat/createcomputing/Registries.java
@@ -1,7 +1,7 @@
 package de.saschat.createcomputing;
 
 import com.simibubi.create.content.logistics.trains.management.edgePoint.TrackTargetingBlockItem;
-import com.simibubi.create.repack.registrate.util.nullness.NonNullBiFunction;
+import com.tterrag.registrate.util.nullness.NonNullBiFunction;
 import de.saschat.createcomputing.blocks.ComputerizedDisplaySourceBlock;
 import de.saschat.createcomputing.blocks.ComputerizedDisplayTargetBlock;
 import de.saschat.createcomputing.blocks.ComputerizedRedstoneLinkBlock;
@@ -21,12 +21,12 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraftforge.client.event.EntityRenderersEvent;
+import net.minecraftforge.data.event.GatherDataEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
-import net.minecraftforge.forge.event.lifecycle.GatherDataEvent;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
@@ -37,7 +37,7 @@ import java.util.function.Supplier;
 public class Registries {
     public static DeferredRegister<Item> ITEM_REGISTRY = DeferredRegister.create(ForgeRegistries.ITEMS, CreateComputingMod.MOD_ID);
     public static DeferredRegister<Block> BLOCK_REGISTRY = DeferredRegister.create(ForgeRegistries.BLOCKS, CreateComputingMod.MOD_ID);
-    public static DeferredRegister<BlockEntityType<?>> TILE_REGISTRY = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITIES, CreateComputingMod.MOD_ID);
+    public static DeferredRegister<BlockEntityType<?>> TILE_REGISTRY = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITY_TYPES, CreateComputingMod.MOD_ID);
 
     public static RegistryObject<Block> registerBlock(String name, Supplier<Block> blockSupplier) {
         CreateComputingMod.LOGGER.info("Queuing block: " + name);

--- a/src/main/java/de/saschat/createcomputing/Utils.java
+++ b/src/main/java/de/saschat/createcomputing/Utils.java
@@ -14,12 +14,10 @@ import java.util.Map;
 
 public class Utils {
     public static Item getByName(ResourceLocation loc) {
-        var itemRegistryObject = ForgeRegistries.ITEMS.getEntries().stream().filter(a -> {
-            return a.getValue().getRegistryName().equals(loc);
-        }).findFirst().orElseGet(() -> null);
-        if (itemRegistryObject == null)
+        var itemRegistryObject = ForgeRegistries.ITEMS.getHolder(loc);
+        if (itemRegistryObject.isEmpty())
             return Items.AIR;
-        return itemRegistryObject.getValue();
+        return itemRegistryObject.get().get();
     }
 
     public interface Receiver<T> {

--- a/src/main/java/de/saschat/createcomputing/behaviour/source/TextDisplayBehaviour.java
+++ b/src/main/java/de/saschat/createcomputing/behaviour/source/TextDisplayBehaviour.java
@@ -3,15 +3,14 @@ package de.saschat.createcomputing.behaviour.source;
 import com.simibubi.create.content.logistics.block.display.DisplayLinkContext;
 import com.simibubi.create.content.logistics.block.display.source.DisplaySource;
 import com.simibubi.create.content.logistics.block.display.target.DisplayTargetStats;
-import com.simibubi.create.content.logistics.trains.management.display.FlapDisplayTileEntity;
 import de.saschat.createcomputing.tiles.ComputerizedDisplaySourceTile;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.TextComponent;
 
 import java.util.List;
 
 public class TextDisplayBehaviour extends DisplaySource {
-    public static MutableComponent NIL_TEXT = new TextComponent("");
+    public static MutableComponent NIL_TEXT = Component.literal("");
     @Override
     public List<MutableComponent> provideText(DisplayLinkContext displayLinkContext, DisplayTargetStats displayTargetStats) {
         /*

--- a/src/main/java/de/saschat/createcomputing/peripherals/TrainNetworkObserverPeripheral.java
+++ b/src/main/java/de/saschat/createcomputing/peripherals/TrainNetworkObserverPeripheral.java
@@ -26,12 +26,15 @@ import de.saschat.createcomputing.Utils;
 import de.saschat.createcomputing.api.SmartPeripheral;
 import de.saschat.createcomputing.tiles.TrainNetworkObserverTile;
 import net.minecraft.core.BlockPos;
-import net.minecraft.nbt.*;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.items.ItemStackHandler;
+import net.minecraftforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -132,7 +135,7 @@ public class TrainNetworkObserverPeripheral extends SmartPeripheral {
                 return MethodResult.of(null);
             Carriage.DimensionalCarriageEntity car = carr.get();
             CarriageContraptionEntity ent = car.entity.get();
-            return MethodResult.of(ent.getX(), ent.getY(), ent.getZ(), ent.getLevel().dimension().getRegistryName().toString());
+            return MethodResult.of(ent.getX(), ent.getY(), ent.getZ(), ent.getLevel().dimension().registry().toString());
         });
         addMethod("getTrainSpeed", (iComputerAccess, iLuaContext, iArguments) -> {
             String b = iArguments.getString(0);
@@ -331,7 +334,7 @@ public class TrainNetworkObserverPeripheral extends SmartPeripheral {
         }
         ret.put("type", "item");
         ret.put("count", filter.getCount());
-        ret.put("id", filter.getItem().getRegistryName().toString());
+        ret.put("id", ForgeRegistries.ITEMS.getKey(filter.getItem()).toString());
         ret.put("nbt", blowNBT(filter.getTag()));
         return ret;
     }

--- a/src/main/java/de/saschat/createcomputing/peripherals/handles/RedstoneHandle.java
+++ b/src/main/java/de/saschat/createcomputing/peripherals/handles/RedstoneHandle.java
@@ -7,6 +7,7 @@ import de.saschat.createcomputing.peripherals.ComputerizedRedstoneLinkPeripheral
 import de.saschat.createcomputing.tiles.ComputerizedRedstoneLinkTile;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
+import net.minecraftforge.registries.ForgeRegistries;
 
 import java.util.Arrays;
 import java.util.UUID;
@@ -72,7 +73,7 @@ public class RedstoneHandle {
     }
     @LuaFunction(mainThread = true)
     public final String[] getItems(IArguments arguments) throws LuaException {
-        return Arrays.stream(getHandle().items).map(a -> a.getRegistryName().toString()).collect(Collectors.toList()).toArray(new String[0]);
+        return Arrays.stream(getHandle().items).map(a -> ForgeRegistries.ITEMS.getKey(a).toString()).collect(Collectors.toList()).toArray(new String[0]);
     }
     @LuaFunction
     public final void close() {

--- a/src/main/java/de/saschat/createcomputing/tiles/ComputerizedDisplaySourceTile.java
+++ b/src/main/java/de/saschat/createcomputing/tiles/ComputerizedDisplaySourceTile.java
@@ -10,7 +10,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;

--- a/src/main/java/de/saschat/createcomputing/tiles/ComputerizedRedstoneLinkTile.java
+++ b/src/main/java/de/saschat/createcomputing/tiles/ComputerizedRedstoneLinkTile.java
@@ -19,6 +19,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.registries.ForgeRegistries;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -126,7 +127,7 @@ public class ComputerizedRedstoneLinkTile extends SmartTileEntity {
 
     public static boolean checkItem(Item stack) {
         for (String loc : CreateComputingConfigServer.get().BANNED_LINK_ITEMS.get()) {
-            if (loc.equals(stack.getRegistryName().toString()))
+            if (loc.equals(ForgeRegistries.ITEMS.getKey(stack).toString()))
                 return false;
         }
         return true;

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -44,7 +44,7 @@ modId = "forge" #mandatory
 # Does this dependency have to exist - if not, ordering below must be specified
 mandatory = true #mandatory
 # The version range of the dependency
-versionRange = "[40,)" #mandatory
+versionRange = "[41,)" #mandatory
 # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
 ordering = "NONE"
 # Side this dependency is applied on - BOTH, CLIENT or SERVER
@@ -54,7 +54,7 @@ side = "BOTH"
 modId = "minecraft"
 mandatory = true
 # This version range declares a minimum of the current minecraft version up to but not including the next major version
-versionRange = "[1.18.2,1.19)"
+versionRange = "[1.19.2]"
 ordering = "NONE"
 side = "BOTH"
 [[dependencies.createcomputing]]


### PR DESCRIPTION
Update mod to function on 1.19.2

Some small notes:
- Redstone link might have some issues. Handlers and signals appear to be registered correctly, but Create redstone links do not appear to activate. I'm guessing it's one of the following:
     - Frequency no longer equal due to the changes required for retrieving items from registries. `ItemStack#getRegistryName` no longer exists so that needed some changing.
     - Create made internal changes to its API
     - My computercraft program is just wrong in some way.
     - Note: I'm putting this PR here anyway, could be worth testing with existing setups to see if maybe I just messed up my CC code.
- Added some gradle options to more easily update create, flywheel and registrate.
- Left the jade dependency as-is, it doesn't appear to be used in any way but I could be wrong about that.