### PR TITLE
Move redstone signal functions off the main thread

### DIFF
--- a/src/main/java/de/saschat/createcomputing/peripherals/handles/RedstoneHandle.java
+++ b/src/main/java/de/saschat/createcomputing/peripherals/handles/RedstoneHandle.java
@@ -38,14 +38,13 @@ public class RedstoneHandle {
         return linkPair;
     }
 
-    @LuaFunction(mainThread = true)
+    @LuaFunction(mainThread = false)
     public final void setSignal(IArguments arguments) throws LuaException {
         isOpen();
         int value = arguments.getInt(0);
-        System.out.println("sx: " + value);
         getHandle().provideSignal(value);
     }
-    @LuaFunction(mainThread = true)
+    @LuaFunction(mainThread = false)
     public final int getSignal(IArguments arguments) throws LuaException {
         isOpen();
         return getHandle().retrieveSignal();

--- a/src/main/java/de/saschat/createcomputing/tiles/ComputerizedRedstoneLinkTile.java
+++ b/src/main/java/de/saschat/createcomputing/tiles/ComputerizedRedstoneLinkTile.java
@@ -155,6 +155,7 @@ public class ComputerizedRedstoneLinkTile extends SmartTileEntity {
 
         public boolean registered = false;
 
+        public boolean dirty = false;
         public int sendSignal = 0;
         public int recvSignal = 0;
         ComputerizedRedstoneLinkTile parent;
@@ -218,13 +219,16 @@ public class ComputerizedRedstoneLinkTile extends SmartTileEntity {
         private void dirty() {
             if (parent.getLevel().isClientSide())
                 return;
+            if (dirty) return;
+            dirty = true;
             parent.tasks.add(this::_dirty);
-            parent.setChanged();
         }
 
         private void _dirty() {
+            dirty = false;
             transmit.notifySignalChange();
             receive.notifySignalChange();
+            parent.setChanged();
         }
 
         private void setSignal(int i) {


### PR DESCRIPTION
Improve the computerized redstone link signal functions to be usable off the main thread, allowing for more than one signal change per tick. 

Also slightly optimize dirty marking by only allowing one dirty update to be scheduled at a time since a single call would process every update made.